### PR TITLE
feat: add opencloud support for group endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { HttpClient, HttpOptions } from "./http";
+import { Groups } from "./resources/groups";
 import { Users } from "./resources/users";
 
 /**
@@ -34,6 +35,7 @@ export interface OpenCloudConfig {
 export class OpenCloud {
   /** Access to Users API endpoints */
   public users: Users;
+  public groups: Groups;
 
   /**
    * Creates a new OpenCloud SDK client instance.
@@ -56,6 +58,7 @@ export class OpenCloud {
     });
 
     this.users = new Users(http);
+    this.groups = new Groups(http);
   }
 }
 
@@ -64,3 +67,4 @@ export * from "./errors";
 export type { HttpOptions } from "./http";
 
 export { Users } from "./resources/users";
+export { Groups } from "./resources/groups";

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "../http";
 import type {
   Group,
-  GroupMembershipItemPage,
+  GroupMembershipItemsPage,
   JoinRequestItemsPage,
   ListOptions,
 } from "../types";
@@ -23,7 +23,7 @@ export class Groups {
   /**
    * Retrieves a Roblox group's information by group ID.
    *
-   * @param groupId - The unique user ID (numeric string)
+   * @param groupId - The unique group ID (numeric string)
    * @returns Promise resolving to the groups's data
    * @throws {AuthError} If API key is invalid
    * @throws {OpenCloudError} If the group is not found or other API error occurs
@@ -116,13 +116,13 @@ export class Groups {
   async listGroupMemberships(
     groupId: string,
     options: ListOptions = {},
-  ): Promise<GroupMembershipItemPage> {
+  ): Promise<GroupMembershipItemsPage> {
     const searchParams = new URLSearchParams();
     if (options.maxPageSize)
       searchParams.set("maxPageSize", options.maxPageSize.toString());
     if (options.pageToken) searchParams.set("pageToken", options.pageToken);
 
-    return this.http.request<GroupMembershipItemPage>(
+    return this.http.request<GroupMembershipItemsPage>(
       `/cloud/v2/groups/${groupId}/memberships`,
       {
         method: "GET",

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -1,0 +1,135 @@
+import { HttpClient } from "../http";
+import type {
+  AssetQuotasPage,
+  Group,
+  GroupMembershipItem,
+  GroupMembershipItemPage,
+  JoinRequestItemsPage,
+  ListOptions,
+} from "../types";
+
+/**
+ * API client for Roblox Group endpoints.
+ * Provides methods to retrieve group information, shouts, and group memberships.
+ *
+ * @see https://create.roblox.com/docs/cloud/reference/Group
+ */
+export class Groups {
+  /**
+   * Creates a new Groups API client.
+   *
+   * @param http - HTTP client for making API requests
+   */
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Retrieves a Roblox group's information by group ID.
+   *
+   * @param groupId - The unique user ID (numeric string)
+   * @returns Promise resolving to the groups's data
+   * @throws {AuthError} If API key is invalid
+   * @throws {OpenCloudError} If the group is not found or other API error occurs
+   *
+   * @example
+   * ```typescript
+   * const group = await client.groups.get('123456789');
+   * console.log(group.displayName); // "Roblox"
+   * ```
+   *
+   * @see https://create.roblox.com/docs/cloud/reference/Group#Cloud_GetGroup
+   */
+  async get(groupId: string): Promise<Group> {
+    return this.http.request<Group>(`/cloud/v2/groups/${groupId}`);
+  }
+
+  /**
+   * List join requests under a group. Supports additional filtering.
+   * Supports pagination for large invite-only groups.
+   *
+   * @param groupId - The unique group ID (numeric string)
+   * @param options - List options including pagination and filtering
+   * @param options.maxPageSize - Maximum items per page (default set by API)
+   * @param options.pageToken - Token from previous response for next page
+   * @param options.filter - Filter expression (e.g., "user == 'users/156'")
+   * @returns Promise resolving to a page of group invite items
+   * @throws {AuthError} If API key is invalid
+   * @throws {OpenCloudError} If the group is not found or other API error occurs
+   *
+   * @example
+   * ```typescript
+   * // Get first page of join requests
+   * const page1 = await client.groups.listGroupJoinRequests('123456789', {
+   *   maxPageSize: 50
+   * });
+   *
+   * // Get next page
+   * const page2 = await client.groups.listGroupJoinRequests('123456789', {
+   *   pageToken: page1.nextPageToken
+   * });
+   *
+   * // Filter for a specific user
+   * const user = await client.groups.listGroupJoinRequests('123456789', {
+   *   filter: "user == 'users/156'"
+   * });
+   * ```
+   *
+   * @see https://create.roblox.com/docs/cloud/reference/GroupJoinRequest#Cloud_ListGroupJoinRequests
+   */
+  async listGroupJoinRequests(
+    groupId: string,
+    options: ListOptions & { filter?: string } = {},
+  ): Promise<JoinRequestItemsPage> {
+    const searchParams = new URLSearchParams();
+    if (options.maxPageSize)
+      searchParams.set("maxPageSize", options.maxPageSize.toString());
+    if (options.pageToken) searchParams.set("pageToken", options.pageToken);
+    if (options.filter) searchParams.set("filter", options.filter);
+
+    return this.http.request<JoinRequestItemsPage>(
+      `/cloud/v2/groups/${groupId}/join-requests`,
+      {
+        method: "GET",
+        searchParams,
+      },
+    );
+  }
+
+  /**
+   * List group members in a group.
+   * Supports pagination for high membercounts.
+   *
+   * @param groupId - The unique group ID (numeric string)
+   * @param options - List options for pagination
+   * @param options.maxPageSize - Maximum items per page (default set by API)
+   * @param options.pageToken - Token from previous response for next page
+   * @returns Promise resolving to a page of group membership items
+   * @throws {AuthError} If API key is invalid
+   * @throws {OpenCloudError} If the group is not found or other API error occurs
+   *
+   * @example
+   * ```typescript
+   * const members = await client.groups.listGroupMemberships('123456789');
+   *
+   * console.log(members)
+   * ```
+   *
+   * @see https://create.roblox.com/docs/cloud/reference/GroupMembership#Cloud_ListGroupMemberships
+   */
+  async listGroupMemberships(
+    groupId: string,
+    options: ListOptions = {},
+  ): Promise<GroupMembershipItemPage> {
+    const searchParams = new URLSearchParams();
+    if (options.maxPageSize)
+      searchParams.set("maxPageSize", options.maxPageSize.toString());
+    if (options.pageToken) searchParams.set("pageToken", options.pageToken);
+
+    return this.http.request<GroupMembershipItemPage>(
+      `/cloud/v2/groups/${groupId}/memberships`,
+      {
+        method: "GET",
+        searchParams,
+      },
+    );
+  }
+}

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -1,8 +1,6 @@
 import { HttpClient } from "../http";
 import type {
-  AssetQuotasPage,
   Group,
-  GroupMembershipItem,
   GroupMembershipItemPage,
   JoinRequestItemsPage,
   ListOptions,

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -18,7 +18,7 @@ export class Groups {
    *
    * @param http - HTTP client for making API requests
    */
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   /**
    * Retrieves a Roblox group's information by group ID.

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -1,0 +1,35 @@
+import type { Page } from "./common";
+
+export interface Group {
+  path: string;
+  createTime: string;
+  updateTime: string;
+  id: string;
+  displayName: string;
+  description: string;
+  owner: string;
+  memberCount: number;
+  publicEntryAllowed: boolean;
+  locked: boolean;
+  verified: boolean;
+}
+
+export interface GroupMembershipItem {
+  path: string;
+  createTime: string;
+  updateTime: string;
+  user: string;
+  role: string;
+}
+
+export interface JoinRequestItem {
+  path: string;
+  createTime: string;
+  user: string;
+}
+
+export type GroupMembershipItemsPage = Page<
+  GroupMembershipItem,
+  "groupMemberships"
+>;
+export type JoinRequestItemsPage = Page<JoinRequestItem, "groupJoinRequests">;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./common";
 export * from "./users";
+export * from "./groups";

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -206,37 +206,5 @@ export interface InventoryItem {
   addTime: string;
 }
 
-export interface JoinRequestItem {
-  path: string;
-  createTime: string;
-  user: string;
-}
-
-export interface Group {
-  path: string;
-  createTime: string;
-  updateTime: string;
-  id: string;
-  displayName: string;
-  description: string;
-  owner: string;
-  membercount: number;
-  publicEntryAllowed: boolean;
-  locked: boolean;
-  verified: boolean;
-}
-
-export interface GroupMembershipItem {
-  path: string;
-  createTime: string;
-  updateTime: string;
-  user: string;
-  role: string;
-}
 export type InventoryItemsPage = Page<InventoryItem, "inventoryItems">;
 export type AssetQuotasPage = Page<AssetQuota, "assetQuotas">;
-export type JoinRequestItemsPage = Page<JoinRequestItem, "joinRequestItems">;
-export type GroupMembershipItemPage = Page<
-  GroupMembershipItem,
-  "groupMembershipItems"
->;

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -206,5 +206,35 @@ export interface InventoryItem {
   addTime: string;
 }
 
+export interface JoinRequestItem {
+  path: string;
+  createTime: string;
+  user: string
+}
+
+export interface Group {
+  path: string;
+  createTime: string;
+  updateTime: string;
+  id: string;
+  displayName: string;
+  description: string;
+  owner: string;
+  membercount: number;
+  publicEntryAllowed: boolean;
+  locked: boolean;
+  verified: boolean;
+
+}
+
+export interface GroupMembershipItem {
+  path: string;
+  createTime: string;
+  updateTime: string;
+  user: string;
+  role: string
+}
 export type InventoryItemsPage = Page<InventoryItem, "inventoryItems">;
 export type AssetQuotasPage = Page<AssetQuota, "assetQuotas">;
+export type JoinRequestItemsPage = Page<JoinRequestItem, "joinRequestItems">;
+export type GroupMembershipItemPage = Page<GroupMembershipItem, "groupMembershipItems">;

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -209,7 +209,7 @@ export interface InventoryItem {
 export interface JoinRequestItem {
   path: string;
   createTime: string;
-  user: string
+  user: string;
 }
 
 export interface Group {
@@ -224,7 +224,6 @@ export interface Group {
   publicEntryAllowed: boolean;
   locked: boolean;
   verified: boolean;
-
 }
 
 export interface GroupMembershipItem {
@@ -232,9 +231,12 @@ export interface GroupMembershipItem {
   createTime: string;
   updateTime: string;
   user: string;
-  role: string
+  role: string;
 }
 export type InventoryItemsPage = Page<InventoryItem, "inventoryItems">;
 export type AssetQuotasPage = Page<AssetQuota, "assetQuotas">;
 export type JoinRequestItemsPage = Page<JoinRequestItem, "joinRequestItems">;
-export type GroupMembershipItemPage = Page<GroupMembershipItem, "groupMembershipItems">;
+export type GroupMembershipItemPage = Page<
+  GroupMembershipItem,
+  "groupMembershipItems"
+>;

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import { OpenCloud } from "../src";
+import { makeFetchMock } from "./_utils";
+import type {
+  Group,
+  GroupMembershipItemsPage,
+  JoinRequestItemsPage,
+} from "../src/types";
+
+const baseUrl = "https://apis.roblox.com";
+
+describe("Groups", () => {
+  it("GET /groups/{id}", async () => {
+    const mockGroup: Group = {
+      path: "groups/123456789",
+      createTime: "2020-01-15T10:30:00.000Z",
+      updateTime: "2024-10-15T12:00:00.000Z",
+      id: "123456789",
+      displayName: "Test Group",
+      description: "This is a test group for unit testing",
+      owner: "users/987654321",
+      memberCount: 150,
+      publicEntryAllowed: true,
+      locked: false,
+      verified: true,
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockGroup },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.get("123456789");
+
+    expect(result.id).toBe("123456789");
+    expect(result.displayName).toBe("Test Group");
+    expect(result.memberCount).toBe(150);
+    expect(result.verified).toBe(true);
+    expect(calls[0]?.url.toString()).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789`,
+    );
+  });
+
+  it("GET /groups/{id}/join-requests without options", async () => {
+    const mockJoinRequests: JoinRequestItemsPage = {
+      groupJoinRequests: [
+        {
+          path: "groups/123456789/join-requests/1",
+          createTime: "2024-10-10T08:00:00.000Z",
+          user: "users/111111111",
+        },
+        {
+          path: "groups/123456789/join-requests/2",
+          createTime: "2024-10-11T09:15:00.000Z",
+          user: "users/222222222",
+        },
+      ],
+      nextPageToken: "join-token-123",
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockJoinRequests },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupJoinRequests("123456789");
+
+    expect(result.groupJoinRequests).toHaveLength(2);
+    expect(result.groupJoinRequests[0]?.user).toBe("users/111111111");
+    expect(result.nextPageToken).toBe("join-token-123");
+    expect(calls[0]?.url.toString()).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/join-requests`,
+    );
+  });
+
+  it("GET /groups/{id}/join-requests with pagination", async () => {
+    const mockJoinRequests: JoinRequestItemsPage = {
+      groupJoinRequests: [
+        {
+          path: "groups/123456789/join-requests/3",
+          createTime: "2024-10-12T10:30:00.000Z",
+          user: "users/333333333",
+        },
+      ],
+      nextPageToken: "join-token-456",
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockJoinRequests },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupJoinRequests("123456789", {
+      maxPageSize: 50,
+      pageToken: "previous-token",
+    });
+
+    expect(result.groupJoinRequests).toHaveLength(1);
+    const url = calls[0]?.url.toString();
+    expect(url).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/join-requests?maxPageSize=50&pageToken=previous-token`,
+    );
+  });
+
+  it("GET /groups/{id}/join-requests with filter", async () => {
+    const mockJoinRequests: JoinRequestItemsPage = {
+      groupJoinRequests: [
+        {
+          path: "groups/123456789/join-requests/1",
+          createTime: "2024-10-10T08:00:00.000Z",
+          user: "users/156",
+        },
+      ],
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockJoinRequests },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupJoinRequests("123456789", {
+      filter: "user == 'users/156'",
+    });
+
+    expect(result.groupJoinRequests).toHaveLength(1);
+    expect(result.groupJoinRequests[0]?.user).toBe("users/156");
+    const url = calls[0]?.url.toString();
+    expect(url).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/join-requests?filter=user+%3D%3D+%27users%2F156%27`,
+    );
+  });
+
+  it("GET /groups/{id}/join-requests with all options", async () => {
+    const mockJoinRequests: JoinRequestItemsPage = {
+      groupJoinRequests: [],
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockJoinRequests },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupJoinRequests("123456789", {
+      maxPageSize: 25,
+      pageToken: "token-abc",
+      filter: "user == 'users/999'",
+    });
+
+    expect(result.groupJoinRequests).toHaveLength(0);
+    const url = calls[0]?.url.toString();
+    expect(url).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/join-requests?maxPageSize=25&pageToken=token-abc&filter=user+%3D%3D+%27users%2F999%27`,
+    );
+  });
+
+  it("GET /groups/{id}/memberships without options", async () => {
+    const mockMemberships: GroupMembershipItemsPage = {
+      groupMemberships: [
+        {
+          path: "groups/123456789/memberships/1",
+          createTime: "2020-01-15T10:30:00.000Z",
+          updateTime: "2024-01-15T10:30:00.000Z",
+          user: "users/111111111",
+          role: "groups/123456789/roles/12345",
+        },
+        {
+          path: "groups/123456789/memberships/2",
+          createTime: "2020-02-20T14:45:00.000Z",
+          updateTime: "2023-05-10T09:20:00.000Z",
+          user: "users/222222222",
+          role: "groups/123456789/roles/67890",
+        },
+        {
+          path: "groups/123456789/memberships/3",
+          createTime: "2020-03-10T08:15:00.000Z",
+          updateTime: "2024-10-01T16:00:00.000Z",
+          user: "users/333333333",
+          role: "groups/123456789/roles/11111",
+        },
+      ],
+      nextPageToken: "membership-token-xyz",
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockMemberships },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupMemberships("123456789");
+
+    expect(result.groupMemberships).toHaveLength(3);
+    expect(result.groupMemberships[0]?.user).toBe("users/111111111");
+    expect(result.groupMemberships[1]?.role).toBe(
+      "groups/123456789/roles/67890",
+    );
+    expect(result.nextPageToken).toBe("membership-token-xyz");
+    expect(calls[0]?.url.toString()).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/memberships`,
+    );
+  });
+
+  it("GET /groups/{id}/memberships with pagination", async () => {
+    const mockMemberships: GroupMembershipItemsPage = {
+      groupMemberships: [
+        {
+          path: "groups/123456789/memberships/4",
+          createTime: "2021-06-15T12:00:00.000Z",
+          updateTime: "2024-06-15T12:00:00.000Z",
+          user: "users/444444444",
+          role: "groups/123456789/roles/22222",
+        },
+      ],
+    };
+
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: mockMemberships },
+    ]);
+    const openCloud = new OpenCloud({
+      apiKey: "test-api-key",
+      baseUrl,
+      fetchImpl: fetchMock,
+    });
+
+    const result = await openCloud.groups.listGroupMemberships("123456789", {
+      maxPageSize: 100,
+      pageToken: "next-page-token",
+    });
+
+    expect(result.groupMemberships).toHaveLength(1);
+    expect(result.groupMemberships[0]?.user).toBe("users/444444444");
+    const url = calls[0]?.url.toString();
+    expect(url).toBe(
+      `${baseUrl}/cloud/v2/groups/123456789/memberships?maxPageSize=100&pageToken=next-page-token`,
+    );
+  });
+});


### PR DESCRIPTION
This pull request introduces a new API client for Roblox Group endpoints and adds supporting types for group-related data. The main focus is to provide methods for retrieving group information, listing join requests, and listing group memberships, with robust type definitions to ensure correct usage and API integration.

### New API client for group operations

* Added the `Groups` class in `src/resources/groups.ts`, which provides methods to fetch group details (`get`), list group join requests (`listGroupJoinRequests`), and list group memberships (`listGroupMemberships`). All methods support pagination and filtering where applicable.

### Type definitions for group data

* Introduced new interfaces in `src/types/users.ts` for `Group`, `JoinRequestItem`, and `GroupMembershipItem`, describing the structure of group, join request, and membership data returned by the API.
* Added new paginated types: `JoinRequestItemsPage` and `GroupMembershipItemPage` for handling paginated responses of join requests and memberships.