### PR TITLE
feat: per-request OAuth2 auth override

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,34 @@ pnpm add @relatiohq/opencloud
 yarn add @relatiohq/opencloud
 ```
 
-## Usage
+## Quick Start
 
 ```typescript
 import { OpenCloud } from "@relatiohq/opencloud";
 
+// With API key authentication
 const client = new OpenCloud({
   apiKey: "your-api-key",
 });
 
-// Use the client
 const user = await client.users.get("123456789");
+```
+
+### Per-Request Authentication (OAuth2)
+
+Perfect for multi-tenant applications:
+
+```typescript
+// Create client without default auth
+const client = new OpenCloud();
+
+// Use different credentials per request
+const userClient = client.withAuth({
+  kind: "oauth2",
+  accessToken: "user-access-token",
+});
+
+const groups = await userClient.groups.listGroupMemberships("123456");
 ```
 
 ## Documentation
@@ -42,6 +59,7 @@ Full API documentation is available at [https://opencloud.relatio.cc](https://op
 - Tree-shakeable exports
 - Lightweight with zero dependencies
 - Automatic retry with exponential backoff
+- Flexible authentication
 
 ## Why Use This SDK?
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,17 @@
 import { HttpClient, HttpOptions } from "./http";
 import { Groups } from "./resources/groups";
 import { Users } from "./resources/users";
+import type { AuthConfig } from "./types/auth";
 
 /**
  * Configuration options for initializing the OpenCloud SDK client.
  */
 export interface OpenCloudConfig {
-  /** Roblox Open Cloud API key for authentication */
-  apiKey: string;
+  /**
+   * Roblox Open Cloud API key for authentication.
+   * This is optional and if not provided, you must use withAuth() for per-request authentication.
+   */
+  apiKey?: string;
   /** Custom user agent string for API requests (defaults to "@relatiohq/opencloud") */
   userAgent?: string;
   /** Base URL for the Roblox API (defaults to "https://apis.roblox.com") */
@@ -24,26 +28,34 @@ export interface OpenCloudConfig {
  *
  * @example
  * ```typescript
+ * // Traditional usage with API key
  * const client = new OpenCloud({
  *   apiKey: 'your-api-key-here'
  * });
- *
  * const user = await client.users.get('123456789');
  * console.log(user.displayName);
+ *
+ * // Multi-tenant usage with per-request OAuth2
+ * const client = new OpenCloud(); // No default auth
+ * const userClient = client.withAuth({
+ *   kind: "oauth2",
+ *   accessToken: "user-token"
+ * });
+ * const groups = await userClient.groups.listMemberships("123456");
  * ```
  */
 export class OpenCloud {
-  /** Access to Users API endpoints */
-  public users: Users;
-  public groups: Groups;
+  public users!: Users;
+  public groups!: Groups;
+  private http!: HttpClient;
 
   /**
    * Creates a new OpenCloud SDK client instance.
    *
    * @param config - Configuration options for the client
    */
-  constructor(config: OpenCloudConfig) {
-    const http = new HttpClient({
+  constructor(config: OpenCloudConfig = {}) {
+    this.http = new HttpClient({
       baseUrl: config.baseUrl ?? "https://apis.roblox.com",
       retry: config.retry ?? {
         attempts: 4,
@@ -51,14 +63,60 @@ export class OpenCloud {
         baseMs: 250,
       },
       headers: {
-        "x-api-key": config.apiKey,
+        ...(config.apiKey ? { "x-api-key": config.apiKey } : {}),
         "user-agent": config.userAgent ?? "@relatiohq/opencloud",
       },
       fetchImpl: config.fetchImpl,
     });
 
+    this.initializeResources(this.http);
+  }
+
+  /**
+   * Initializes all resource endpoints with the provided HTTP client.
+   * @private
+   */
+  private initializeResources(http: HttpClient): void {
     this.users = new Users(http);
     this.groups = new Groups(http);
+  }
+
+  /**
+   * Creates a scoped client instance with per-request authentication.
+   * This allows reusing a single client while providing different credentials for each request.
+   *
+   * @param auth - Authentication configuration to use for this scope
+   * @returns A new scoped OpenCloud instance with the provided auth
+   *
+   * @example
+   * ```typescript
+   * const client = new OpenCloud(); // No default auth
+   *
+   * // OAuth2 authentication
+   * const userClient = client.withAuth({
+   *   kind: "oauth2",
+   *   accessToken: "user-token-here"
+   * });
+   * const groups = await userClient.groups.listMemberships("123456");
+   *
+   * // API key authentication
+   * const adminClient = client.withAuth({
+   *   kind: "apiKey",
+   *   apiKey: "admin-key-here"
+   * });
+   * const user = await adminClient.users.get("789");
+   * ```
+   */
+  withAuth(auth: AuthConfig): OpenCloud {
+    const scoped = Object.create(this) as OpenCloud;
+
+    const scopedHttp = Object.create(this.http) as HttpClient;
+    scopedHttp.authOverride = auth;
+
+    scoped.http = scopedHttp;
+    scoped.initializeResources(scopedHttp);
+
+    return scoped;
   }
 }
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,17 @@
+/**
+ * Authentication configuration for API requests.
+ * Supports both API key and OAuth2 bearer token authentication.
+ */
+export type AuthConfig =
+  | {
+      /** Authentication method using an API key */
+      kind: "apiKey";
+      /** The API key value */
+      apiKey: string;
+    }
+  | {
+      /** Authentication method using OAuth2 */
+      kind: "oauth2";
+      /** The OAuth2 access token */
+      accessToken: string;
+    };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./auth";
 export * from "./common";
 export * from "./users";
 export * from "./groups";

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { OpenCloud } from "../src";
+import { AuthError } from "../src/errors";
+import { makeFetchMock } from "./_utils";
+
+describe("Per-request auth override", () => {
+  it("should allow creating a client without default auth", () => {
+    const client = new OpenCloud();
+    expect(client).toBeDefined();
+  });
+
+  it("should throw AuthError when no auth is provided", async () => {
+    const { fetchMock } = makeFetchMock([
+      { status: 200, body: { displayName: "Test User" } },
+    ]);
+
+    const client = new OpenCloud({ fetchImpl: fetchMock });
+
+    await expect(client.users.get("123")).rejects.toThrow(AuthError);
+    await expect(client.users.get("123")).rejects.toThrow(
+      "No authentication provided",
+    );
+  });
+
+  it("should use OAuth2 token from withAuth()", async () => {
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: { displayName: "Test User" } },
+    ]);
+
+    const client = new OpenCloud({ fetchImpl: fetchMock });
+    const scopedClient = client.withAuth({
+      kind: "oauth2",
+      accessToken: "test-token-123",
+    });
+
+    await scopedClient.users.get("123456");
+
+    expect(calls.length).toBe(1);
+    const headers = calls[0]?.init?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer test-token-123");
+    expect(headers.has("x-api-key")).toBe(false);
+  });
+
+  it("should use API key from withAuth()", async () => {
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: { displayName: "Test User" } },
+    ]);
+
+    const client = new OpenCloud({ fetchImpl: fetchMock });
+    const scopedClient = client.withAuth({
+      kind: "apiKey",
+      apiKey: "test-api-key-456",
+    });
+
+    await scopedClient.users.get("123456");
+
+    expect(calls.length).toBe(1);
+    const headers = calls[0]?.init?.headers as Headers;
+    expect(headers.get("x-api-key")).toBe("test-api-key-456");
+    expect(headers.has("authorization")).toBe(false);
+  });
+
+  it("should override default API key with OAuth2 token", async () => {
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: { displayName: "Test User" } },
+    ]);
+
+    const client = new OpenCloud({
+      apiKey: "default-key",
+      fetchImpl: fetchMock,
+    });
+    const scopedClient = client.withAuth({
+      kind: "oauth2",
+      accessToken: "override-token",
+    });
+
+    await scopedClient.users.get("123456");
+
+    expect(calls.length).toBe(1);
+    const headers = calls[0]?.init?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer override-token");
+    // The original x-api-key should still be present from default config,
+    // but the authorization header takes precedence
+    expect(headers.get("x-api-key")).toBe("default-key");
+  });
+
+  it("should allow multiple scoped clients from same base client", async () => {
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: { displayName: "Test User" } },
+    ]);
+
+    const client = new OpenCloud({ fetchImpl: fetchMock });
+
+    const user1Client = client.withAuth({
+      kind: "oauth2",
+      accessToken: "token-1",
+    });
+    const user2Client = client.withAuth({
+      kind: "oauth2",
+      accessToken: "token-2",
+    });
+
+    await user1Client.users.get("111");
+    await user2Client.users.get("222");
+
+    expect(calls.length).toBe(2);
+
+    const headers1 = calls[0]?.init?.headers as Headers;
+    expect(headers1.get("authorization")).toBe("Bearer token-1");
+
+    const headers2 = calls[1]?.init?.headers as Headers;
+    expect(headers2.get("authorization")).toBe("Bearer token-2");
+  });
+
+  it("should work in multi-tenant server scenario", async () => {
+    const { fetchMock, calls } = makeFetchMock([
+      { status: 200, body: { groupMemberships: [] } },
+    ]);
+
+    // Simulate a multi-tenant server
+    const client = new OpenCloud({ fetchImpl: fetchMock });
+
+    const handleRequest = async (userToken: string) => {
+      const userClient = client.withAuth({
+        kind: "oauth2",
+        accessToken: userToken,
+      });
+      return await userClient.groups.listGroupMemberships("123456");
+    };
+
+    await handleRequest("user-1-token");
+    await handleRequest("user-2-token");
+
+    expect(calls.length).toBe(2);
+
+    const headers1 = calls[0]?.init?.headers as Headers;
+    expect(headers1.get("authorization")).toBe("Bearer user-1-token");
+
+    const headers2 = calls[1]?.init?.headers as Headers;
+    expect(headers2.get("authorization")).toBe("Bearer user-2-token");
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -8,7 +8,11 @@ const baseUrl = "https://apis.roblox.com";
 describe("HttpClient", () => {
   it("returns parsed JSON on 200", async () => {
     const { fetchMock } = makeFetchMock([{ status: 200, body: { ok: true } }]);
-    const http = new HttpClient({ baseUrl, fetchImpl: fetchMock });
+    const http = new HttpClient({
+      baseUrl,
+      fetchImpl: fetchMock,
+      headers: { "x-api-key": "test-key" },
+    });
 
     const response = await http.request<{ ok: boolean }>("/cloud/v2/ping");
     expect(response.ok).toBe(true);
@@ -52,6 +56,7 @@ describe("HttpClient", () => {
     const http = new HttpClient({
       baseUrl,
       fetchImpl: fetchMock,
+      headers: { "x-api-key": "test-key" },
       retry: { attempts: 3, backoff: "fixed", baseMs: 0 }, // make retry instant for test
     });
 
@@ -68,6 +73,7 @@ describe("HttpClient", () => {
     const http = new HttpClient({
       baseUrl,
       fetchImpl: fetchMock,
+      headers: { "x-api-key": "test-key" },
       retry: { attempts: 1, backoff: "fixed", baseMs: 0 },
     });
 


### PR DESCRIPTION
## Description

This PR implements per-request authentication support, enabling OAuth2 bearer token authentication alongside the existing API key authentication. This is accomplished through a new `withAuth()` method that allows reusing a single client instance with different credentials per request.

## Related Issue

<!-- Link to the issue this PR addresses. Use "Fixes #123" or "Closes #123" to auto-close the issue when merged -->

Closes #5 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality) 
- [x] ✅ Test update

## Changes Made

<!-- List the specific changes made in this PR -->

- Added AuthConfig type supporting both apiKey and oauth2 authentication methods
- Implemented withAuth() method on OpenCloud class for per-request auth
- Made OpenCloudConfig.apiKey optional (was previously required)
- Added authOverride property to HttpClient
- Refactored resource initialization into initializeResources() helper for maintainability
- Updated authentication documentation guide with OAuth2 examples and multi-tenant patterns
- Updated README with quick start examples for both auth methods

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass (`pnpm test`)
- [x] Added new tests for new functionality
- [x] Tested manually (describe below)

## Code Quality

<!-- Confirm you've followed the project's standards -->

- [x] My code follows the project's coding style
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm format` to format my code
- [x] I have run `pnpm typecheck` and there are no type errors
- [x] I have reviewed my own code

## Documentation

<!-- Ensure documentation is up to date -->

- [x] I have updated the relevant documentation (if applicable)
- [x] I have added/updated JSDoc comments for new/modified code

## Additional Context

<!-- Add any other context about the PR here -->

The proposed API design in #5 was not ideal after researching further and chose the `withAuth()` pattern over alternative approaches (request-level parameters, middleware, etc.) because it avoids modifying method signatures across all resources

## Checklist

<!-- Final checks before submitting -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have rebased my branch on the latest `main` branch
- [x] I have tested my changes against the Roblox Open Cloud API (if applicable)
- [x] This PR is ready for review

---

<!--
Thank you for contributing to @relatiohq/opencloud! 🎉
Your contribution helps make this SDK better for everyone.
-->
