### PR TITLE
fix(universes): Update GameJoinRestriction interface

### DIFF
--- a/src/types/universes.ts
+++ b/src/types/universes.ts
@@ -86,7 +86,7 @@ export interface SpeechAssetResponse extends SpeechAssetOperation {
 
 export interface GameJoinRestriction {
   active: boolean;
-  duration: string;
+  duration?: string;
   privateReason: string;
   displayReason: string;
   excludeAltAccounts: boolean;


### PR DESCRIPTION
## Description

Makes the `duration` property optional to align with the API.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

<!-- List the specific changes made in this PR -->

- `duration` inside `GameJoinRestriction` is now optional

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass (`pnpm test`)
- [ ] Tested manually (describe below)

### Manual Testing

<!-- If you tested manually, describe how -->

```typescript
// Example code showing how you tested this change
```

## Code Quality

<!-- Confirm you've followed the project's standards -->

- [x] My code follows the project's coding style
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm format` to format my code
- [ ] I have run `pnpm typecheck` and there are no type errors
- [x] I have reviewed my own code

## Documentation

<!-- Ensure documentation is up to date -->

- [ ] I have updated the relevant documentation (if applicable)
- [ ] I have added/updated JSDoc comments for new/modified code

## Additional Context

<img width="713" height="179" alt="image" src="https://github.com/user-attachments/assets/04e31a70-92f3-4353-bde6-c4181377c144" />

## Checklist

<!-- Final checks before submitting -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have rebased my branch on the latest `main` branch
- [ ] I have tested my changes against the Roblox Open Cloud API (if applicable)
- [ ] This PR is ready for review

---

<!--
Thank you for contributing to @relatiohq/opencloud! 🎉
Your contribution helps make this SDK better for everyone.
-->
